### PR TITLE
feat(autocomplete-plus): #18 attribute for the <ismodule/> tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ### Fixed
 
-Travis CI `sudo` deprecation warning.
+-   Travis CI `sudo` deprecation warning.
 
 ### Added
 
--   Added "attribute" for the `<ismodule />` tag and it's description in the official Salesforce Commerce Cloud B2C documentation.
+-   Added "attribute" for the `<ismodule/>` tag and it's description in the official Salesforce Commerce Cloud B2C documentation.
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-sfcc",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Adds syntax highlighting, completions, and snippets to ISML & Demandware Script files in Atom.",
   "main": "./lib/index",
   "keywords": [


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

feat(autocomplete-plus): #18 attribute for the <ismodule/> tag

### Does this close any currently open issues?

#18 

### Any other comments?

None.

### Checklist

Check all those that are applicable and complete. Put an `x` between the brackets (without spaces).

-   [x] Merged with latest `master` branch
-   [x] Add change details to `CHANGELOG.md`
-   [x] Added new test to [spec](https://github.com/matteobertoldo/language-sfcc/tree/master/spec) directory
-   [x] Travis &amp; Appveyor CI passes (Linux/Windows support)
